### PR TITLE
Make smooth scrolling more responsive

### DIFF
--- a/src/ui/custom_widgets.py
+++ b/src/ui/custom_widgets.py
@@ -297,6 +297,17 @@ class AutoScrollArea(ScrollArea):
         except AttributeError:
             # Older versions may not have this helper; fall back to stylesheet
             self.setStyleSheet("QScrollArea{border:none;background:transparent}")
+
+        # Tune smooth scroll to be grippy/responsive, not slidy
+        # Default QFluentWidgets: duration=400, stepRatio=1.5, acceleration=1
+        try:
+            vs = self.scrollDelagate.verticalSmoothScroll
+            vs.duration = 150
+            vs.stepRatio = 1.0
+            vs.acceleration = 0
+        except Exception:
+            pass
+
         self._current_scale = 1.0
         self._scroll_timer = QTimer(self)
         self._scroll_timer.timeout.connect(self._perform_auto_scroll)

--- a/src/ui/tabs/main_tab.py
+++ b/src/ui/tabs/main_tab.py
@@ -854,6 +854,16 @@ class MainTab(QWidget):
         except Exception:
             pass
 
+        # Tune the smooth scroll to be grippy/responsive, not slidy
+        # Default: duration=400, stepRatio=1.5, acceleration=1 — too much glide
+        try:
+            vs = self.main_scroll_area.scrollDelagate.verticalSmoothScroll
+            vs.duration = 150       # was 400 — stop gliding quickly
+            vs.stepRatio = 1.0      # was 1.5 — scroll exactly what wheel sends
+            vs.acceleration = 0     # was 1 — no momentum buildup
+        except Exception:
+            pass
+
         scroll_content_widget = QWidget()
         scroll_content_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         scroll_content_widget.setStyleSheet(f"background-color: {CalculatorTheme.TAB_BG};")


### PR DESCRIPTION
Adjust smooth-scroll tuning to make wheel scrolling grippier and less glidy. Set verticalSmoothScroll.duration=150, stepRatio=1.0 and acceleration=0 in AutoScrollArea and MainTab (main_scroll_area) where available. Changes are wrapped in try/except to preserve compatibility with older versions that may not expose these attributes.