### PR TITLE
Disable QFluentWidgets smooth scrolling

### DIFF
--- a/src/ui/custom_widgets.py
+++ b/src/ui/custom_widgets.py
@@ -298,13 +298,9 @@ class AutoScrollArea(ScrollArea):
             # Older versions may not have this helper; fall back to stylesheet
             self.setStyleSheet("QScrollArea{border:none;background:transparent}")
 
-        # Tune smooth scroll to be grippy/responsive, not slidy
-        # Default QFluentWidgets: duration=400, stepRatio=1.5, acceleration=1
+        # Disable smooth scrolling — native Qt wheel scroll is grippy and responsive
         try:
-            vs = self.scrollDelagate.verticalSmoothScroll
-            vs.duration = 150
-            vs.stepRatio = 1.0
-            vs.acceleration = 0
+            self.setSmoothMode(SmoothMode.NO_SMOOTH, Qt.Vertical)
         except Exception:
             pass
 

--- a/src/ui/tabs/main_tab.py
+++ b/src/ui/tabs/main_tab.py
@@ -19,7 +19,7 @@ from qfluentwidgets import (
     ComboBox, SpinBox, PrimaryPushButton,
     CardWidget, TitleLabel, BodyLabel, CaptionLabel,
     FluentIcon, PushButton, DropDownPushButton, RoundMenu, Action,
-    ScrollArea,
+    ScrollArea, SmoothMode,
     FluentIconBase, StrongBodyLabel
 )
 
@@ -854,13 +854,10 @@ class MainTab(QWidget):
         except Exception:
             pass
 
-        # Tune the smooth scroll to be grippy/responsive, not slidy
-        # Default: duration=400, stepRatio=1.5, acceleration=1 — too much glide
+        # Disable QFluentWidgets smooth scrolling — it causes a slidy/laggy feel
+        # Fall back to native Qt wheel scrolling which is immediate and grippy
         try:
-            vs = self.main_scroll_area.scrollDelagate.verticalSmoothScroll
-            vs.duration = 150       # was 400 — stop gliding quickly
-            vs.stepRatio = 1.0      # was 1.5 — scroll exactly what wheel sends
-            vs.acceleration = 0     # was 1 — no momentum buildup
+            self.main_scroll_area.setSmoothMode(SmoothMode.NO_SMOOTH, Qt.Vertical)
         except Exception:
             pass
 


### PR DESCRIPTION
Replace manual tuning of QFluentWidgets' verticalSmoothScroll with disabling smooth scrolling via setSmoothMode(SmoothMode.NO_SMOOTH, Qt.Vertical) in custom_widgets.py and main_tab.py. This falls back to native Qt wheel scrolling which is more immediate and responsive; changes are wrapped in try/except to preserve compatibility with older versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical scrolling behavior in main content areas by disabling smooth scrolling for a more direct, responsive wheel-scroll experience.
  * Made scrolling settings safer by keeping the app functional even if the updated scroll mode isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->