### PR TITLE
fix(ci): use --jq to extract upload_url instead of --silent|ConvertFr…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,8 +169,8 @@ jobs:
           $repo = "${{ github.repository }}"
 
           # --- Get the upload_url from the release (strip the {?name,label} suffix) ---
-          $release = gh api "repos/$repo/releases/$releaseId" --silent | ConvertFrom-Json
-          $uploadUrl = $release.upload_url -replace '\{.*\}', ''
+          $uploadUrl = (gh api "repos/$repo/releases/$releaseId" --jq ".upload_url") -replace '\{.*\}', ''
+          if (!$uploadUrl) { throw "Could not get upload_url for release $releaseId" }
           Write-Host "Upload URL: $uploadUrl"
 
           # --- Delete any existing assets with the same name (re-runs) ---


### PR DESCRIPTION
…om-Json

--silent suppresses stdout so ConvertFrom-Json got an empty string, making upload_url empty and causing 404s. Switched to --jq .upload_url which outputs the field directly. Added a guard that throws early if upload_url is empty.