### PR TITLE
Replace gotrue imports with supabase_auth

### DIFF
--- a/pyinstaller_hooks/hook-supabase.py
+++ b/pyinstaller_hooks/hook-supabase.py
@@ -16,8 +16,8 @@ from PyInstaller.utils.hooks import collect_submodules
 # Only collect Python submodules (no package data/binaries)
 hiddenimports = collect_submodules("supabase") + [
     # Core dependencies commonly used by supabase client:
-    "gotrue",
-    "gotrue.errors",
+    "supabase_auth",
+    "supabase_auth.errors",
     "postgrest",
     "postgrest.exceptions",
     "storage3",

--- a/src/core/supabase_manager.py
+++ b/src/core/supabase_manager.py
@@ -11,7 +11,7 @@ except ImportError:
     pass
 from supabase import create_client, Client
 from postgrest.exceptions import APIError
-from gotrue.errors import AuthApiError
+from supabase_auth.errors import AuthApiError
 from src.core.db_manager import DBManager  # To get Supabase URL and Key
 from src.core.supabase_error_handler import SupabaseErrorHandler
 from datetime import datetime

--- a/src/ui/background_workers.py
+++ b/src/ui/background_workers.py
@@ -1,6 +1,6 @@
 from PyQt5.QtCore import QThread, pyqtSignal
 from postgrest.exceptions import APIError
-from gotrue.errors import AuthApiError
+from supabase_auth.errors import AuthApiError
 import hashlib
 import json
 import logging


### PR DESCRIPTION
Update imports to use the new supabase_auth package instead of gotrue. Adjusted PyInstaller hook hiddenimports to collect 'supabase_auth' and 'supabase_auth.errors' and replaced occurrences of 'gotrue.errors' with 'supabase_auth.errors' in src/core/supabase_manager.py and src/ui/background_workers.py to match the updated dependency structure and ensure proper bundling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the updated authentication package, helping ensure sign-in-related errors are handled correctly.
  * Fixed application bundling so the correct authentication components are included in packaged builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->